### PR TITLE
Update jspahrsummers/xcconfigs repo URL

### DIFF
--- a/CrushBootstrap/Other-Sources/Configuration/jspahrsummers-xcconfigs/UpdateXCConfigs.sh
+++ b/CrushBootstrap/Other-Sources/Configuration/jspahrsummers-xcconfigs/UpdateXCConfigs.sh
@@ -18,7 +18,7 @@ cd "$(dirname "$0")"
 
 say "Grabbing latest xcconfigs..."
 
-curl -fSL#$CURL_QUIET_OPT 'https://github.com/jspahrsummers/xcconfigs/archive/master.zip' | tar xz --strip-components=1
+curl -fSL#$CURL_QUIET_OPT 'https://github.com/jspahrsummers/xcconfigs/archive/master.tar.gz' | tar xz --strip-components=1
 
 # No commit checking stuff in quiet mode
 $QUIET && exit 0


### PR DESCRIPTION
 - Change jspahrsummers/xcconfigs archive URL from a .zip extension to
   .tar.gz so that the tar command on the other end of the pipe can
   process the input properly

Otherwise, this is the error I'm getting:
```bash
 ~  Development  ruby -e "$(curl -fsSL https://raw.github.com/crushlovely/Amaro/master/tiramisu)"
    ___           ___
   /\  \         /\__\
  /  \  \       / /  /
 / /\ \__\     / /__/
 \ \ \/__/  &  \ \  \
  \ \__\        \ \__\
   \/__/         \/__/  Amaro v1.0.0

Checking environment... 👍
Repository: https://github.com/crushlovely/Amaro.git
Branch: master

New project name: TestProj
Class prefix (optional; 2 or preferably 3 characters): TP
Your name (blank for George Kontridze): George Kontridze
Organization name (blank for The Company): The Company
Bundle ID domain (blank for com.thecompany): com.thecompany

🎉  It's time to build your project!
Pausing for 3 seconds in case you change your mind. Press any key to abort.

Initializing local repository... 👍
Fetching repository... 👍
Merging... 👍
Cleaning up... 👍
Renaming project files... 👍
Renaming prefixed files... 👍
Updating file contents... 👍
Committing... 👍
Pulling latest xcconfigs... 💀
Error
Command: 'TestProj/Other-Sources/Configuration/jspahrsummers-xcconfigs/UpdateXCConfigs.sh' -q
Output:
gzip: stdin has more than one entry--rest ignored
tar: Child returned status 2
tar: Error is not recoverable: exiting now
```
